### PR TITLE
Fix extras_require type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.md", "r") as fh:
 
 extras_require={
     "Conversion": ["cairosvg>=2.7.0"],
-},
+}
 
 # fix accidental uppercasing in v0.4.0
 extras_require["conversion"] = extras_require["Conversion"]


### PR DESCRIPTION
Trailing comma makes `extras_require` a tuple instead of a dict, resulting in an indexing error on line 16.